### PR TITLE
Remove use of window to check for Float64Array

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -203,7 +203,7 @@ function determineStatsOptions(options?: IBaseOptions) {
  */
 export function boxplotStats(arr: readonly number[] | Float32Array | Float64Array, options: IBaseOptions): IBoxPlot {
   const vs =
-    window.Float64Array != null && !(arr instanceof Float32Array || arr instanceof Float64Array)
+    typeof Float64Array !== 'undefined' && !(arr instanceof Float32Array || arr instanceof Float64Array)
       ? Float64Array.from(arr)
       : arr;
   const r = boxplots(vs, determineStatsOptions(options));
@@ -244,7 +244,7 @@ export function violinStats(arr: readonly number[], options: IViolinOptions): IV
     return undefined;
   }
   const vs =
-    window.Float64Array != null && !(arr instanceof Float32Array || arr instanceof Float64Array)
+    typeof Float64Array !== 'undefined' && !(arr instanceof Float32Array || arr instanceof Float64Array)
       ? Float64Array.from(arr)
       : arr;
   const stats = boxplots(vs, determineStatsOptions(options));


### PR DESCRIPTION
Hi,

I'd like to suggest this change to make your library work on Node.js as it previously did.
[Some changes of last year](https://github.com/sgratzl/chartjs-chart-boxplot/commit/201218067bf4d7c480fc6d6836ab2445b04e9595) introduced the use of `window`, which is not available on Node.js.

I'd suggest to use `typeof` as it is always safe: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#interaction_with_undeclared_and_uninitialized_variables

Thank you!
Stefan